### PR TITLE
Declare support for PHP8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,16 +4,14 @@ on:
       - 'master'
 jobs:
   run:
-    runs-on: 'ubuntu-latest'
-
     strategy:
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
         phpunit-versions: ['latest']
         include:
-          - operating-system: 'ubuntu-latest'
-            php-versions: '7.2'
+          - php-versions: '7.2'
             phpunit-versions: '8.5.13'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +22,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: pdo_sqlite
           coverage: xdebug
-          tools: composer, phpunit
+          tools: composer, phpunit:${{ matrix.phpunit-versions }}
 
       - name: install everything
         run: composer install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,38 @@
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  run:
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0']
+        phpunit-versions: ['latest']
+        include:
+          - operating-system: 'ubuntu-latest'
+            php-versions: '7.2'
+            phpunit-versions: '8.5.13'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: pdo_sqlite
+          coverage: xdebug
+          tools: composer, phpunit
+
+      - name: install everything
+        run: composer install
+
+      - name: run tests
+        run: phpunit --coverage-text --coverage-clover=coverage.clover
+
+      - name: upload coverage data
+        run: |
+          curl -O https://scrutinizer-ci.com/ocular.phar
+          php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Specification based querying for Doctrine2",
     "require": {
         "doctrine/orm": "^2.5",
-        "php": "^7.2"
+        "php": "^7.2|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/tests/Stub/DummyFixtures.php
+++ b/tests/Stub/DummyFixtures.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace FrankDeJonge\DoctrineQuerySpecification\Tests\Stub;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 class DummyFixtures implements FixtureInterface
 {


### PR DESCRIPTION
The package is perfectly compatible with PHP8, but it declares it's only compatible with `^7.2`. Updated `composer.json` to reflect that.

The package declares it depends on `doctrine/orm:^2.5`, but that includes doctrine 2.8, where `Doctrine\Common\Persistence` became `Doctrine\Persistence`. This does not break any functionality, but break the tests because makes `DummyFixtures` sad. I've updated it, now the tests run fine in >= 2.8 (but would break in earlier ORM packages).

Also added github actions workflow to run the tests.