### PR TITLE
README: Fix the ArticleHasNameLike code sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ class ArticleHasNameLike implements QueryConstraint
     }
 }
 
-$publishedArticles = $articleRepository->findBySpecification(new );
+$publishedArticles = $articleRepository->findBySpecification(new ArticleHasNameLike('Awesome Name'));
 ```
 
 ### Query modifiers.


### PR DESCRIPTION
A tiny change in the README samples. It just missed the "new ArticleHasNameLike...".