### PR TITLE
Doctrine ORM update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
     "name": "frankdejonge/doctrine-query-specification",
     "description": "Specification based querying for Doctrine2",
     "require": {
-        "doctrine/orm": "^2.5",
-        "php": "^7.4|^8.0"
+        "doctrine/orm": "^3.",
+        "php": "^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.5",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/cache": "^1.1",
-        "doctrine/annotations": "^1.13"
+        "doctrine/cache": "^2.1",
+        "doctrine/annotations": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/SpecificationAwareRepositoryTrait.php
+++ b/src/SpecificationAwareRepositoryTrait.php
@@ -59,5 +59,5 @@ trait SpecificationAwareRepositoryTrait
      *
      * @return QueryBuilder
      */
-    abstract public function createQueryBuilder($alias, $indexBy = null);
+    abstract public function createQueryBuilder($alias, $indexBy = null): QueryBuilder;
 }


### PR DESCRIPTION
- Updated to v3 of doctrine/orm
- Updated to have minimum PHP 8.1
- Added missing return type